### PR TITLE
Switch to the `org.dflib.jjava:jupyter-jvm-basekernel:1.0-M3`

### DIFF
--- a/dflib-jupyter/pom.xml
+++ b/dflib-jupyter/pom.xml
@@ -64,9 +64,9 @@
 
         <!-- Provided dependencies -->
         <dependency>
-            <groupId>io.github.spencerpark</groupId>
+            <groupId>org.dflib.jjava</groupId>
             <artifactId>jupyter-jvm-basekernel</artifactId>
-            <version>2.3.0</version>
+            <version>1.0-M3</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dflib-jupyter/src/main/java/org/dflib/jupyter/DFLibJupyter.java
+++ b/dflib-jupyter/src/main/java/org/dflib/jupyter/DFLibJupyter.java
@@ -3,14 +3,14 @@ package org.dflib.jupyter;
 import org.dflib.DataFrame;
 import org.dflib.Series;
 import org.dflib.echarts.EChartHtml;
+import org.dflib.jjava.jupyter.kernel.BaseKernel;
+import org.dflib.jjava.jupyter.kernel.display.RenderFunction;
+import org.dflib.jjava.jupyter.kernel.display.Renderer;
+import org.dflib.jjava.jupyter.kernel.display.mime.MIMEType;
 import org.dflib.jupyter.render.DataFrameRenderer;
 import org.dflib.jupyter.render.EChartRenderer;
 import org.dflib.jupyter.render.MutableTabularPrinter;
 import org.dflib.jupyter.render.SeriesRenderer;
-import io.github.spencerpark.jupyter.kernel.BaseKernel;
-import io.github.spencerpark.jupyter.kernel.display.RenderFunction;
-import io.github.spencerpark.jupyter.kernel.display.Renderer;
-import io.github.spencerpark.jupyter.kernel.display.mime.MIMEType;
 
 /**
  * A bridge between DFLib and Jupyter notebook environment. Bootstraps DFLib renderers into a Jupyter notebook under

--- a/dflib-jupyter/src/main/java/org/dflib/jupyter/DFLibJupyterExtension.java
+++ b/dflib-jupyter/src/main/java/org/dflib/jupyter/DFLibJupyterExtension.java
@@ -1,0 +1,22 @@
+package org.dflib.jupyter;
+
+import org.dflib.jjava.jupyter.Extension;
+import org.dflib.jjava.jupyter.kernel.BaseKernel;
+
+public class DFLibJupyterExtension implements Extension {
+
+    private static final String STARTUP_SCRIPT =
+                    "import org.dflib.jupyter.*;\n" +
+                    "import org.dflib.*;\n" +
+                    // must call init method here, to process everything in order inside code executor
+                    "DFLibJupyter.init(getKernelInstance());";
+
+    @Override
+    public void install(BaseKernel kernel) {
+        try {
+            kernel.eval(STARTUP_SCRIPT);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dflib-jupyter/src/main/java/org/dflib/jupyter/render/DataFrameRenderer.java
+++ b/dflib-jupyter/src/main/java/org/dflib/jupyter/render/DataFrameRenderer.java
@@ -1,10 +1,10 @@
 package org.dflib.jupyter.render;
 
 import org.dflib.DataFrame;
+import org.dflib.jjava.jupyter.kernel.display.RenderContext;
+import org.dflib.jjava.jupyter.kernel.display.RenderFunction;
+import org.dflib.jjava.jupyter.kernel.display.mime.MIMEType;
 import org.dflib.print.Printer;
-import io.github.spencerpark.jupyter.kernel.display.RenderContext;
-import io.github.spencerpark.jupyter.kernel.display.RenderFunction;
-import io.github.spencerpark.jupyter.kernel.display.mime.MIMEType;
 
 public class DataFrameRenderer implements RenderFunction<DataFrame> {
 

--- a/dflib-jupyter/src/main/java/org/dflib/jupyter/render/EChartRenderer.java
+++ b/dflib-jupyter/src/main/java/org/dflib/jupyter/render/EChartRenderer.java
@@ -1,9 +1,9 @@
 package org.dflib.jupyter.render;
 
-import io.github.spencerpark.jupyter.kernel.display.RenderContext;
-import io.github.spencerpark.jupyter.kernel.display.RenderFunction;
-import io.github.spencerpark.jupyter.kernel.display.mime.MIMEType;
 import org.dflib.echarts.EChartHtml;
+import org.dflib.jjava.jupyter.kernel.display.RenderContext;
+import org.dflib.jjava.jupyter.kernel.display.RenderFunction;
+import org.dflib.jjava.jupyter.kernel.display.mime.MIMEType;
 
 import java.util.Set;
 
@@ -18,11 +18,11 @@ public class EChartRenderer implements RenderFunction<EChartHtml> {
 
     @Override
     public void render(EChartHtml data, RenderContext context) {
-        boolean canRender = SUPPORTED_TYPES.stream().filter(context::wantsDataRenderedAs).findFirst().isPresent();
+        boolean canRender = SUPPORTED_TYPES.stream().anyMatch(context::wantsDataRenderedAs);
 
         if (canRender) {
             String content = toString(data);
-            SUPPORTED_TYPES.stream().forEach(t -> context.renderIfRequested(t, () -> content));
+            SUPPORTED_TYPES.forEach(t -> context.renderIfRequested(t, () -> content));
         }
     }
 

--- a/dflib-jupyter/src/main/java/org/dflib/jupyter/render/SeriesRenderer.java
+++ b/dflib-jupyter/src/main/java/org/dflib/jupyter/render/SeriesRenderer.java
@@ -1,10 +1,10 @@
 package org.dflib.jupyter.render;
 
 import org.dflib.Series;
+import org.dflib.jjava.jupyter.kernel.display.RenderContext;
+import org.dflib.jjava.jupyter.kernel.display.RenderFunction;
+import org.dflib.jjava.jupyter.kernel.display.mime.MIMEType;
 import org.dflib.print.Printer;
-import io.github.spencerpark.jupyter.kernel.display.RenderContext;
-import io.github.spencerpark.jupyter.kernel.display.RenderFunction;
-import io.github.spencerpark.jupyter.kernel.display.mime.MIMEType;
 
 public class SeriesRenderer implements RenderFunction<Series> {
 

--- a/dflib-jupyter/src/main/resources/META-INF/services/org.dflib.jjava.jupyter.Extension
+++ b/dflib-jupyter/src/main/resources/META-INF/services/org.dflib.jjava.jupyter.Extension
@@ -1,0 +1,1 @@
+org.dflib.jupyter.DFLibJupyterExtension


### PR DESCRIPTION
This PR switches `dflib-jupyter` to the yet to be released `org.dflib.jjava:jupyter-jvm-basekernel:1.0-M3` and implements an extension for the JJava kernel. The extension automatically executes the following code:

```java
import org.dflib.jupyter.*;
import org.dflib.*;

DFLibJupyter.init(getKernelInstance());
```