### PR TITLE
Efficient fixed-size `BooleanBitsetSeries` builder

### DIFF
--- a/dflib/src/main/java/org/dflib/BooleanSeries.java
+++ b/dflib/src/main/java/org/dflib/BooleanSeries.java
@@ -1,6 +1,7 @@
 package org.dflib;
 
 import org.dflib.builder.BoolAccum;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.op.BooleanSeriesOps;
 import org.dflib.op.ReplaceOp;
 import org.dflib.series.BooleanArraySeries;
@@ -282,14 +283,8 @@ public interface BooleanSeries extends Series<Boolean> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         BooleanSeries anotherBool = (BooleanSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getBool(i) == anotherBool.getBool(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getBool(i) == anotherBool.getBool(i), len);
     }
 
     @Override
@@ -303,13 +298,7 @@ public interface BooleanSeries extends Series<Boolean> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         BooleanSeries anotherBool = (BooleanSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getBool(i) != anotherBool.getBool(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getBool(i) != anotherBool.getBool(i), len);
     }
 }

--- a/dflib/src/main/java/org/dflib/BooleanSeries.java
+++ b/dflib/src/main/java/org/dflib/BooleanSeries.java
@@ -4,7 +4,6 @@ import org.dflib.builder.BoolAccum;
 import org.dflib.builder.BoolBuilder;
 import org.dflib.op.BooleanSeriesOps;
 import org.dflib.op.ReplaceOp;
-import org.dflib.series.BooleanArraySeries;
 import org.dflib.series.BooleanIndexedSeries;
 import org.dflib.series.FalseSeries;
 import org.dflib.series.TrueSeries;

--- a/dflib/src/main/java/org/dflib/DoubleSeries.java
+++ b/dflib/src/main/java/org/dflib/DoubleSeries.java
@@ -1,7 +1,7 @@
 package org.dflib;
 
+import org.dflib.builder.BoolBuilder;
 import org.dflib.op.ReplaceOp;
-import org.dflib.series.BooleanArraySeries;
 import org.dflib.series.DoubleArraySeries;
 import org.dflib.series.DoubleIndexedSeries;
 import org.dflib.series.FalseSeries;
@@ -308,14 +308,8 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         DoubleSeries as = (DoubleSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getDouble(i) == as.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getDouble(i) == as.getDouble(i), len);
     }
 
     @Override
@@ -329,14 +323,8 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         DoubleSeries as = (DoubleSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getDouble(i) != as.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getDouble(i) != as.getDouble(i), len);
     }
 
     /**
@@ -463,13 +451,7 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getDouble(i) < s.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getDouble(i) < s.getDouble(i), len);
     }
 
     default BooleanSeries le(DoubleSeries s) {
@@ -478,13 +460,7 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getDouble(i) <= s.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getDouble(i) <= s.getDouble(i), len);
     }
 
     default BooleanSeries gt(DoubleSeries s) {
@@ -493,13 +469,7 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getDouble(i) > s.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getDouble(i) > s.getDouble(i), len);
     }
 
 
@@ -509,13 +479,7 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getDouble(i) >= s.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getDouble(i) >= s.getDouble(i), len);
     }
 
     default BooleanSeries between(DoubleSeries from, DoubleSeries to) {
@@ -526,13 +490,9 @@ public interface DoubleSeries extends Series<Double> {
             throw new IllegalArgumentException("'to' Series size " + to.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            double d = this.getDouble(i);
-            data[i] = d >= from.getDouble(i) && d <= to.getDouble(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> {
+            double v = this.getDouble(i);
+            return v >= from.getDouble(i) && v <= to.getDouble(i);
+        }, len);
     }
 }

--- a/dflib/src/main/java/org/dflib/FloatSeries.java
+++ b/dflib/src/main/java/org/dflib/FloatSeries.java
@@ -1,8 +1,8 @@
 package org.dflib;
 
+import org.dflib.builder.BoolBuilder;
 import org.dflib.f.FloatPredicate;
 import org.dflib.op.ReplaceOp;
-import org.dflib.series.BooleanArraySeries;
 import org.dflib.series.FalseSeries;
 import org.dflib.series.FloatArraySeries;
 import org.dflib.series.FloatIndexedSeries;
@@ -305,14 +305,8 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         FloatSeries as = (FloatSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getFloat(i) == as.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getFloat(i) == as.getFloat(i), len);
     }
 
     @Override
@@ -326,14 +320,8 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         FloatSeries as = (FloatSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getFloat(i) != as.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getFloat(i) != as.getFloat(i), len);
     }
 
     /**
@@ -454,12 +442,7 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getFloat(i) < s.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getFloat(i) < s.getFloat(i), len);
     }
 
     default BooleanSeries le(FloatSeries s) {
@@ -468,12 +451,7 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getFloat(i) <= s.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getFloat(i) <= s.getFloat(i), len);
     }
 
     default BooleanSeries gt(FloatSeries s) {
@@ -482,12 +460,7 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getFloat(i) > s.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getFloat(i) > s.getFloat(i), len);
     }
 
 
@@ -497,12 +470,7 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getFloat(i) >= s.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getFloat(i) >= s.getFloat(i), len);
     }
 
     default BooleanSeries between(FloatSeries from, FloatSeries to) {
@@ -513,13 +481,9 @@ public interface FloatSeries extends Series<Float> {
             throw new IllegalArgumentException("'to' Series size " + to.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            float d = this.getFloat(i);
-            data[i] = d >= from.getFloat(i) && d <= to.getFloat(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> {
+            float v = this.getFloat(i);
+            return v >= from.getFloat(i) && v <= to.getFloat(i);
+        }, len);
     }
 }

--- a/dflib/src/main/java/org/dflib/IntSeries.java
+++ b/dflib/src/main/java/org/dflib/IntSeries.java
@@ -1,7 +1,7 @@
 package org.dflib;
 
+import org.dflib.builder.BoolBuilder;
 import org.dflib.op.ReplaceOp;
-import org.dflib.series.BooleanArraySeries;
 import org.dflib.series.FalseSeries;
 import org.dflib.series.IntArraySeries;
 import org.dflib.series.IntIndexedSeries;
@@ -316,14 +316,8 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         IntSeries anotherInt = (IntSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getInt(i) == anotherInt.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getInt(i) == anotherInt.getInt(i), len);
     }
 
     @Override
@@ -337,14 +331,8 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
         IntSeries anotherInt = (IntSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getInt(i) != anotherInt.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getInt(i) != anotherInt.getInt(i), len);
     }
 
     /**
@@ -476,13 +464,7 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getInt(i) < s.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getInt(i) < s.getInt(i), len);
     }
 
 
@@ -492,13 +474,7 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getInt(i) <= s.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getInt(i) <= s.getInt(i), len);
     }
 
 
@@ -508,13 +484,7 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getInt(i) > s.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getInt(i) > s.getInt(i), len);
     }
 
 
@@ -524,13 +494,7 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getInt(i) >= s.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getInt(i) >= s.getInt(i), len);
     }
 
 
@@ -542,13 +506,9 @@ public interface IntSeries extends Series<Integer> {
             throw new IllegalArgumentException("'to' Series size " + to.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
+        return BoolBuilder.buildSeries(i -> {
             int v = this.getInt(i);
-            data[i] = v >= from.getInt(i) && v <= to.getInt(i);
-        }
-
-        return new BooleanArraySeries(data);
+            return v >= from.getInt(i) && v <= to.getInt(i);
+        }, len);
     }
 }

--- a/dflib/src/main/java/org/dflib/LongSeries.java
+++ b/dflib/src/main/java/org/dflib/LongSeries.java
@@ -1,7 +1,7 @@
 package org.dflib;
 
+import org.dflib.builder.BoolBuilder;
 import org.dflib.op.ReplaceOp;
-import org.dflib.series.BooleanArraySeries;
 import org.dflib.series.FalseSeries;
 import org.dflib.series.LongArraySeries;
 import org.dflib.series.LongIndexedSeries;
@@ -314,14 +314,8 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        LongSeries anotherInt = (LongSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getLong(i) == anotherInt.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        LongSeries anotherLong = (LongSeries) s;
+        return BoolBuilder.buildSeries(i -> getLong(i) == anotherLong.getLong(i), len);
     }
 
     @Override
@@ -335,14 +329,8 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        LongSeries anotherInt = (LongSeries) s;
-
-        for (int i = 0; i < len; i++) {
-            data[i] = getLong(i) != anotherInt.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        LongSeries anotherLong = (LongSeries) s;
+        return BoolBuilder.buildSeries(i -> getLong(i) != anotherLong.getLong(i), len);
     }
 
     /**
@@ -473,13 +461,7 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getLong(i) < s.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getLong(i) < s.getLong(i), len);
     }
 
 
@@ -489,13 +471,7 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getLong(i) <= s.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getLong(i) <= s.getLong(i), len);
     }
 
 
@@ -505,13 +481,7 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getLong(i) > s.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getLong(i) > s.getLong(i), len);
     }
 
 
@@ -521,13 +491,7 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = this.getLong(i) >= s.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> getLong(i) >= s.getLong(i), len);
     }
 
 
@@ -539,13 +503,9 @@ public interface LongSeries extends Series<Long> {
             throw new IllegalArgumentException("'to' Series size " + to.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            long v = this.getLong(i);
-            data[i] = v >= from.getLong(i) && v <= to.getLong(i);
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> {
+           long v = getLong(i);
+           return v >= from.getLong(i) && v <= to.getLong(i);
+        }, len);
     }
 }

--- a/dflib/src/main/java/org/dflib/Series.java
+++ b/dflib/src/main/java/org/dflib/Series.java
@@ -1,6 +1,7 @@
 package org.dflib;
 
 import org.dflib.agg.SeriesAggregator;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.SeriesByElementBuilder;
 import org.dflib.op.ReplaceOp;
 import org.dflib.series.ArraySeries;
@@ -63,7 +64,7 @@ public interface Series<T> extends Iterable<T> {
     }
 
     static BooleanSeries ofBool(boolean... bools) {
-        return new BooleanArraySeries(bools);
+        return BoolBuilder.buildSeries(i -> bools[i], bools.length);
     }
 
     static IntSeries ofInt(int... ints) {
@@ -197,13 +198,7 @@ public interface Series<T> extends Iterable<T> {
     // TODO: functionally, this is a duplicate of "locate()"
     default BooleanSeries compactBool(BoolValueMapper<? super T> mapper) {
         int len = size();
-
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = mapper.map(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> mapper.map(get(i)), len);
     }
 
     /**
@@ -519,13 +514,7 @@ public interface Series<T> extends Iterable<T> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = Objects.equals(get(i), s.get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> Objects.equals(get(i), s.get(i)), len);
     }
 
     /**
@@ -540,12 +529,7 @@ public interface Series<T> extends Iterable<T> {
             throw new IllegalArgumentException("Another Series size " + s.size() + " is not the same as this size " + len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = !Objects.equals(get(i), s.get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !Objects.equals(get(i), s.get(i)), len);
     }
 
     BooleanSeries isNull();
@@ -564,18 +548,9 @@ public interface Series<T> extends Iterable<T> {
      * the predicate.
      */
     default BooleanSeries locate(Predicate<T> predicate) {
-
         // even for primitive Series it is slightly faster to implement "locate" directly than delegating
         // to "locateXyz", because the predicate signature requires primitive boxing
-
-        int len = size();
-        boolean[] matches = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            matches[i] = predicate.test(get(i));
-        }
-
-        return new BooleanArraySeries(matches);
+        return BoolBuilder.buildSeries(i -> predicate.test(get(i)), size());
     }
 
     /**

--- a/dflib/src/main/java/org/dflib/builder/BoolBuilder.java
+++ b/dflib/src/main/java/org/dflib/builder/BoolBuilder.java
@@ -1,7 +1,6 @@
 package org.dflib.builder;
 
 import org.dflib.BooleanSeries;
-import org.dflib.Series;
 import org.dflib.series.BooleanBitsetSeries;
 import org.dflib.series.FalseSeries;
 

--- a/dflib/src/main/java/org/dflib/builder/BoolBuilder.java
+++ b/dflib/src/main/java/org/dflib/builder/BoolBuilder.java
@@ -34,7 +34,7 @@ public class BoolBuilder {
      */
     public static BooleanSeries buildSeries(BoolGenerator generator, int size) {
         if (size == 0) {
-            return Series.ofBool();
+            return new BooleanBitsetSeries(new long[0], 0);
         }
         long[] data = fill(generator, size);
         if(data.length == 0) {

--- a/dflib/src/main/java/org/dflib/builder/BoolBuilder.java
+++ b/dflib/src/main/java/org/dflib/builder/BoolBuilder.java
@@ -1,0 +1,78 @@
+package org.dflib.builder;
+
+import org.dflib.BooleanSeries;
+import org.dflib.Series;
+import org.dflib.series.BooleanBitsetSeries;
+import org.dflib.series.FalseSeries;
+
+/**
+ * Utility class that creates boolean bitset-based series.
+ * <p>
+ * From the functional point of view this is a specialized and optimized version of {@link BoolAccum} intended for an internal use.
+ * <p>
+ * Main difference with the accumulators API is that builder should know the final size of the series.
+ *
+ * @see BooleanBitsetSeries
+ * @see BoolAccum
+ *
+ * @since 2.0.0
+ */
+public class BoolBuilder {
+
+    private static final int INDEX_BIT_SHIFT = 6;
+
+    private BoolBuilder() {
+    }
+
+    /**
+     * Build boolean series of a fixed size, using provided function as a value generator.
+     * Generator function will be called with values from 0 to size - 1 as a parameter.
+     *
+     * @param generator function that generates values, must be capable of providing at least {@code size} elements
+     * @param size target size of the generated series
+     * @return boolean series
+     */
+    public static BooleanSeries buildSeries(BoolGenerator generator, int size) {
+        if (size == 0) {
+            return Series.ofBool();
+        }
+        long[] data = fill(generator, size);
+        if(data.length == 0) {
+            return new FalseSeries(size);
+        }
+        return new BooleanBitsetSeries(data, size);
+    }
+
+    private static long[] fill(BoolGenerator generator, int size) {
+        int i=0;
+        while(i < size && !generator.get(i)) {
+            // noop, just skip initial `false` values
+            i++;
+        }
+        // no values at all
+        if(i == size){
+            return new long[0];
+        }
+
+        long[] data = new long[1 + ((size - 1) >> INDEX_BIT_SHIFT)];
+        long element = 0L;
+        for (; i < size; i += Long.SIZE) {
+            for (int j = i; j < i + Long.SIZE && j < size; j++) {
+                if (generator.get(j)) {
+                    element |= 1L << j;
+                }
+            }
+            data[i >> INDEX_BIT_SHIFT] = element;
+            element = 0L;
+        }
+        return data;
+    }
+
+    /**
+     * Function to generate values for a boolean series
+     */
+    @FunctionalInterface
+    public interface BoolGenerator {
+        boolean get(int i);
+    }
+}

--- a/dflib/src/main/java/org/dflib/exp/map/MapCondition1.java
+++ b/dflib/src/main/java/org/dflib/exp/map/MapCondition1.java
@@ -5,7 +5,7 @@ import org.dflib.Condition;
 import org.dflib.DataFrame;
 import org.dflib.Exp;
 import org.dflib.Series;
-import org.dflib.builder.BoolAccum;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.exp.Exp1;
 
 import java.util.function.Function;
@@ -27,29 +27,17 @@ public class MapCondition1<F> extends Exp1<F, Boolean> implements Condition {
     }
 
     protected static <F> Function<Series<F>, BooleanSeries> valToSeriesWithNulls(Predicate<F> predicate) {
-        return s -> {
-            int len = s.size();
-            BoolAccum accum = new BoolAccum(len);
-            for (int i = 0; i < len; i++) {
-                F v = s.get(i);
-                accum.pushBool(predicate.test(v));
-            }
-
-            return accum.toSeries();
-        };
+        return s -> BoolBuilder.buildSeries(i -> {
+            F v = s.get(i);
+            return predicate.test(v);
+        }, s.size());
     }
 
     protected static <F> Function<Series<F>, BooleanSeries> valToSeries(Predicate<F> predicate) {
-        return s -> {
-            int len = s.size();
-            BoolAccum accum = new BoolAccum(len);
-            for (int i = 0; i < len; i++) {
-                F v = s.get(i);
-                accum.pushBool(v != null ? predicate.test(v) : false);
-            }
-
-            return accum.toSeries();
-        };
+        return s -> BoolBuilder.buildSeries(i -> {
+            F v = s.get(i);
+            return v != null && predicate.test(v);
+        }, s.size());
     }
 
     private final Function<Series<F>, BooleanSeries> op;

--- a/dflib/src/main/java/org/dflib/exp/map/MapCondition2.java
+++ b/dflib/src/main/java/org/dflib/exp/map/MapCondition2.java
@@ -5,7 +5,7 @@ import org.dflib.Condition;
 import org.dflib.DataFrame;
 import org.dflib.Exp;
 import org.dflib.Series;
-import org.dflib.builder.BoolAccum;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.exp.Exp2;
 
 import java.util.function.BiFunction;
@@ -26,17 +26,11 @@ public class MapCondition2<L, R> extends Exp2<L, R, Boolean> implements Conditio
     }
 
     protected static <L, R> BiFunction<Series<L>, Series<R>, BooleanSeries> valToSeries(BiPredicate<L, R> predicate) {
-        return (ls, rs) -> {
-            int len = ls.size();
-            BoolAccum accum = new BoolAccum(len);
-            for (int i = 0; i < len; i++) {
-                L l = ls.get(i);
-                R r = rs.get(i);
-                accum.pushBool(l != null && r != null ? predicate.test(l, r) : false);
-            }
-
-            return accum.toSeries();
-        };
+        return (ls, rs) -> BoolBuilder.buildSeries(i -> {
+            L l = ls.get(i);
+            R r = rs.get(i);
+            return l != null && r != null && predicate.test(l, r);
+        }, ls.size());
     }
 
     private final BiFunction<Series<L>, Series<R>, BooleanSeries> op;

--- a/dflib/src/main/java/org/dflib/exp/map/MapCondition3.java
+++ b/dflib/src/main/java/org/dflib/exp/map/MapCondition3.java
@@ -5,7 +5,7 @@ import org.dflib.Condition;
 import org.dflib.DataFrame;
 import org.dflib.Exp;
 import org.dflib.Series;
-import org.dflib.builder.BoolAccum;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.exp.Exp3;
 import org.dflib.f.Function3;
 import org.dflib.f.Predicate3;
@@ -36,18 +36,12 @@ public class MapCondition3<One, Two, Three> extends Exp3<One, Two, Three, Boolea
 
     protected static <One, Two, Three>
     Function3<Series<One>, Series<Two>, Series<Three>, BooleanSeries> valToSeries(Predicate3<One, Two, Three> predicate) {
-        return (s1, s2, s3) -> {
-            int len = s1.size();
-            BoolAccum accum = new BoolAccum(len);
-            for (int i = 0; i < len; i++) {
-                One one = s1.get(i);
-                Two two = s2.get(i);
-                Three three = s3.get(i);
-                accum.pushBool(one != null && two != null && three != null ? predicate.test(one, two, three) : false);
-            }
-
-            return accum.toSeries();
-        };
+        return (s1, s2, s3) -> BoolBuilder.buildSeries(i -> {
+            One one = s1.get(i);
+            Two two = s2.get(i);
+            Three three = s3.get(i);
+            return one != null && two != null && three != null && predicate.test(one, two, three);
+        }, s1.size());
     }
 
     private final Function3<Series<One>, Series<Two>, Series<Three>, BooleanSeries> op;

--- a/dflib/src/main/java/org/dflib/op/BooleanSeriesOps.java
+++ b/dflib/src/main/java/org/dflib/op/BooleanSeriesOps.java
@@ -1,7 +1,7 @@
 package org.dflib.op;
 
 import org.dflib.BooleanSeries;
-import org.dflib.series.BooleanArraySeries;
+import org.dflib.builder.BoolBuilder;
 
 public class BooleanSeriesOps {
 
@@ -22,18 +22,13 @@ public class BooleanSeriesOps {
             }
         }
 
-        boolean[] and = new boolean[h];
-        for (int i = 0; i < h; i++) {
-
+        return BoolBuilder.buildSeries(i -> {
             boolean b = series[0].getBool(i);
             for (int j = 1; j < w; j++) {
                 b = b && series[j].getBool(i);
             }
-
-            and[i] = b;
-        }
-
-        return new BooleanArraySeries(and);
+            return b;
+        }, h);
     }
 
     public static BooleanSeries orAll(BooleanSeries... series) {
@@ -53,17 +48,12 @@ public class BooleanSeriesOps {
             }
         }
 
-        boolean[] or = new boolean[h];
-        for (int i = 0; i < h; i++) {
-
+        return BoolBuilder.buildSeries(i -> {
             boolean b = series[0].getBool(i);
             for (int j = 1; j < w; j++) {
                 b = b || series[j].getBool(i);
             }
-
-            or[i] = b;
-        }
-
-        return new BooleanArraySeries(or);
+            return b;
+        }, h);
     }
 }

--- a/dflib/src/main/java/org/dflib/series/BooleanBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanBaseSeries.java
@@ -479,9 +479,11 @@ public abstract class BooleanBaseSeries implements BooleanSeries {
         }
 
         if (iTrue < 0) {
-            return new BooleanArraySeries(iFalse < 0 ? new boolean[0] : new boolean[]{false});
+            return iFalse < 0 ? Series.ofBool() : Series.ofBool(false);
         } else {
-            return new BooleanArraySeries(iFalse < 0 ? new boolean[]{true} : iTrue < iFalse ? new boolean[]{true, false} : new boolean[]{false, true});
+            return iFalse < 0
+                    ? Series.ofBool(true)
+                    : iTrue < iFalse ? Series.ofBool(true, false) : Series.ofBool(false, true);
         }
     }
 

--- a/dflib/src/main/java/org/dflib/series/BooleanBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanBaseSeries.java
@@ -339,34 +339,15 @@ public abstract class BooleanBaseSeries implements BooleanSeries {
     private BooleanSeries replaceBoolean(BooleanSeries condition, boolean with) {
         int len = size();
         int r = Math.min(len, condition.size());
-        boolean[] bools = new boolean[len];
 
-        for (int i = 0; i < r; i++) {
-            bools[i] = condition.getBool(i) ? with : getBool(i);
-        }
-
-        for (int i = r; i < len; i++) {
-            bools[i] = getBool(i);
-        }
-
-        return new BooleanArraySeries(bools);
+        return BoolBuilder.buildSeries(i -> i < r && condition.getBool(i) ? with : getBool(i), len);
     }
 
     private BooleanSeries replaceNoMatchBoolean(BooleanSeries condition, boolean with) {
-
         int len = size();
         int r = Math.min(len, condition.size());
-        boolean[] bools = new boolean[len];
 
-        for (int i = 0; i < r; i++) {
-            bools[i] = condition.getBool(i) ? getBool(i) : with;
-        }
-
-        if (len > r) {
-            Arrays.fill(bools, r, len, with);
-        }
-
-        return new BooleanArraySeries(bools);
+        return BoolBuilder.buildSeries(i -> i < r && condition.getBool(i) ? getBool(i) : with, len);
     }
 
     private Series<Boolean> nullify(BooleanSeries condition) {

--- a/dflib/src/main/java/org/dflib/series/BooleanBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanBaseSeries.java
@@ -11,6 +11,7 @@ import org.dflib.Sorter;
 import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
 import org.dflib.builder.BoolAccum;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.ObjectAccum;
 import org.dflib.concat.SeriesConcat;
@@ -110,18 +111,9 @@ public abstract class BooleanBaseSeries implements BooleanSeries {
 
     private BooleanSeries selectAsBooleanSeries(IntSeries positions) {
 
-        int h = positions.size();
-
-        boolean[] data = new boolean[h];
-
-        for (int i = 0; i < h; i++) {
-            // unlike SelectSeries, we do not expect negative ints in the index.
-            // So if it happens, let it fall through to "getLong()" and fail there
-            int index = positions.getInt(i);
-            data[i] = getBool(index);
-        }
-
-        return new BooleanArraySeries(data);
+        // unlike SelectSeries, we do not expect negative ints in the index.
+        // So if it happens, let it fall through to "getLong()" and fail there
+        return BoolBuilder.buildSeries(i -> getBool(positions.getInt(i)), positions.size());
     }
 
     @Override
@@ -428,12 +420,7 @@ public abstract class BooleanBaseSeries implements BooleanSeries {
             return new FalseSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> set.contains(get(i)), len);
     }
 
     @Override
@@ -455,12 +442,7 @@ public abstract class BooleanBaseSeries implements BooleanSeries {
             return new TrueSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = !set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !set.contains(get(i)), len);
     }
 
     @Override
@@ -520,12 +502,7 @@ public abstract class BooleanBaseSeries implements BooleanSeries {
             return this;
         }
 
-        boolean[] not = new boolean[size];
-        for (int i = 0; i < size; i++) {
-            not[i] = !getBool(i);
-        }
-
-        return new BooleanArraySeries(not);
+        return BoolBuilder.buildSeries(i -> !getBool(i), size);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/BooleanBitsetSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanBitsetSeries.java
@@ -33,10 +33,10 @@ public class BooleanBitsetSeries extends BooleanBaseSeries {
 
     @Override
     public boolean getBool(int index) {
-        int i = index >> INDEX_BIT_SHIFT;
-        if (i >= data.length) {
-            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + data.length);
+        if (index >= size) {
+            throw new ArrayIndexOutOfBoundsException("Index: " + index + ", Size: " + size);
         }
+        int i = index >> INDEX_BIT_SHIFT;
         return (this.data[i] & (1L << index)) != 0;
     }
 

--- a/dflib/src/main/java/org/dflib/series/BooleanBitsetSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanBitsetSeries.java
@@ -4,6 +4,7 @@ import org.dflib.BooleanSeries;
 import org.dflib.IntSeries;
 import org.dflib.Sorter;
 import org.dflib.builder.BoolAccum;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.sort.SeriesSorter;
 
 import java.util.Comparator;
@@ -153,13 +154,7 @@ public class BooleanBitsetSeries extends BooleanBaseSeries {
     }
 
     private BooleanSeries selectAsBooleanSeries(IntSeries positions) {
-        int len = positions.size();
-        BoolAccum accum = new BoolAccum(len);
-        for (int i = 0; i < len; i++) {
-            int index = positions.getInt(i);
-            accum.pushBool(getUnchecked(index));
-        }
-        return accum.toSeries();
+        return BoolBuilder.buildSeries(i -> getUnchecked(positions.getInt(i)), positions.size());
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/BooleanIndexedSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanIndexedSeries.java
@@ -3,6 +3,7 @@ package org.dflib.series;
 import org.dflib.BooleanSeries;
 import org.dflib.IntSeries;
 import org.dflib.Series;
+import org.dflib.builder.BoolBuilder;
 
 import java.util.Objects;
 
@@ -132,16 +133,8 @@ public class BooleanIndexedSeries extends BooleanBaseSeries {
         }
 
         BooleanSeries materialize() {
-
             int h = includePositions.size();
-
-            boolean[] data = new boolean[h];
-
-            for (int i = 0; i < h; i++) {
-                data[i] = getBool(i);
-            }
-
-            return new BooleanArraySeries(data);
+            return BoolBuilder.buildSeries(this::getBool, h);
         }
     }
 }

--- a/dflib/src/main/java/org/dflib/series/DoubleBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/DoubleBaseSeries.java
@@ -11,6 +11,7 @@ import org.dflib.SeriesGroupBy;
 import org.dflib.Sorter;
 import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.DoubleAccum;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.ObjectAccum;
@@ -300,15 +301,7 @@ public abstract class DoubleBaseSeries implements DoubleSeries {
 
     @Override
     public BooleanSeries locateDouble(DoublePredicate predicate) {
-        int len = size();
-
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = predicate.test(getDouble(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> predicate.test(getDouble(i)), size());
     }
 
     @Override
@@ -487,12 +480,7 @@ public abstract class DoubleBaseSeries implements DoubleSeries {
             return new FalseSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> set.contains(get(i)), len);
     }
 
     @Override
@@ -515,12 +503,7 @@ public abstract class DoubleBaseSeries implements DoubleSeries {
             return new TrueSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = !set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !set.contains(get(i)), len);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/FloatBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/FloatBaseSeries.java
@@ -11,6 +11,7 @@ import org.dflib.SeriesGroupBy;
 import org.dflib.Sorter;
 import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.FloatAccum;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.ObjectAccum;
@@ -300,14 +301,7 @@ public abstract class FloatBaseSeries implements FloatSeries {
 
     @Override
     public BooleanSeries locateFloat(FloatPredicate predicate) {
-        int len = size();
-
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = predicate.test(getFloat(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> predicate.test(getFloat(i)), size());
     }
 
     @Override
@@ -486,12 +480,7 @@ public abstract class FloatBaseSeries implements FloatSeries {
             return new FalseSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> set.contains(get(i)), len);
     }
 
     @Override
@@ -514,12 +503,7 @@ public abstract class FloatBaseSeries implements FloatSeries {
             return new TrueSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = !set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !set.contains(get(i)), len);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/IntBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/IntBaseSeries.java
@@ -10,6 +10,7 @@ import org.dflib.SeriesGroupBy;
 import org.dflib.Sorter;
 import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.ObjectAccum;
 import org.dflib.builder.UniqueIntAccum;
@@ -333,15 +334,7 @@ public abstract class IntBaseSeries implements IntSeries {
 
     @Override
     public BooleanSeries locateInt(IntPredicate predicate) {
-        int len = size();
-
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = predicate.test(getInt(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> predicate.test(getInt(i)), size());
     }
 
     @Override
@@ -520,12 +513,7 @@ public abstract class IntBaseSeries implements IntSeries {
             return new FalseSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> set.contains(get(i)), len);
     }
 
     @Override
@@ -548,12 +536,7 @@ public abstract class IntBaseSeries implements IntSeries {
             return new TrueSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = !set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !set.contains(get(i)), len);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/LongBaseSeries.java
+++ b/dflib/src/main/java/org/dflib/series/LongBaseSeries.java
@@ -11,6 +11,7 @@ import org.dflib.SeriesGroupBy;
 import org.dflib.Sorter;
 import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.LongAccum;
 import org.dflib.builder.ObjectAccum;
@@ -302,15 +303,7 @@ public abstract class LongBaseSeries implements LongSeries {
 
     @Override
     public BooleanSeries locateLong(LongPredicate predicate) {
-        int len = size();
-
-        boolean[] data = new boolean[len];
-
-        for (int i = 0; i < len; i++) {
-            data[i] = predicate.test(getLong(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> predicate.test(getLong(i)), size());
     }
 
     @Override
@@ -491,12 +484,7 @@ public abstract class LongBaseSeries implements LongSeries {
             return new FalseSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> set.contains(get(i)), len);
     }
 
     @Override
@@ -519,12 +507,7 @@ public abstract class LongBaseSeries implements LongSeries {
             return new TrueSeries(len);
         }
 
-        boolean[] data = new boolean[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = !set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !set.contains(get(i)), len);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/ObjectSeries.java
+++ b/dflib/src/main/java/org/dflib/series/ObjectSeries.java
@@ -10,6 +10,7 @@ import org.dflib.SeriesGroupBy;
 import org.dflib.Sorter;
 import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
+import org.dflib.builder.BoolBuilder;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.ObjectAccum;
 import org.dflib.concat.SeriesConcat;
@@ -356,26 +357,12 @@ public abstract class ObjectSeries<T> implements Series<T> {
 
     @Override
     public BooleanSeries isNull() {
-        int s = size();
-
-        boolean[] data = new boolean[s];
-        for (int i = 0; i < s; i++) {
-            data[i] = get(i) == null;
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> get(i) == null, size());
     }
 
     @Override
     public BooleanSeries isNotNull() {
-        int s = size();
-
-        boolean[] data = new boolean[s];
-        for (int i = 0; i < s; i++) {
-            data[i] = get(i) != null;
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> get(i) != null, size());
     }
 
     @Override
@@ -388,13 +375,7 @@ public abstract class ObjectSeries<T> implements Series<T> {
         }
 
         Set<?> set = new HashSet<>(Arrays.asList(values));
-
-        boolean[] data = new boolean[s];
-        for (int i = 0; i < s; i++) {
-            data[i] = set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> set.contains(get(i)), s);
     }
 
     @Override
@@ -407,13 +388,7 @@ public abstract class ObjectSeries<T> implements Series<T> {
         }
 
         Set<?> set = new HashSet<>(Arrays.asList(values));
-
-        boolean[] data = new boolean[s];
-        for (int i = 0; i < s; i++) {
-            data[i] = !set.contains(get(i));
-        }
-
-        return new BooleanArraySeries(data);
+        return BoolBuilder.buildSeries(i -> !set.contains(get(i)), s);
     }
 
     @Override

--- a/dflib/src/test/java/org/dflib/builder/BoolBuilderTest.java
+++ b/dflib/src/test/java/org/dflib/builder/BoolBuilderTest.java
@@ -1,0 +1,89 @@
+package org.dflib.builder;
+
+import org.dflib.BooleanSeries;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BoolBuilderTest {
+
+    @Test
+    void fillTrue1() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> true, 1);
+
+        assertEquals(1, booleans.size());
+        assertTrue(booleans.get(0));
+    }
+
+    @Test
+    void fillTrue64() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> true, 64);
+
+        assertEquals(64, booleans.size());
+        assertTrue(booleans.get(0));
+        assertTrue(booleans.get(62));
+        assertTrue(booleans.get(63));
+    }
+
+    @Test
+    void fillTrue65() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> true, 65);
+
+        assertEquals(65, booleans.size());
+        assertTrue(booleans.get(0));
+        assertTrue(booleans.get(63));
+        assertTrue(booleans.get(64));
+    }
+
+    @Test
+    void fillTrue128() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> true, 128);
+
+        assertEquals(128, booleans.size());
+        assertTrue(booleans.get(0));
+        assertTrue(booleans.get(63));
+        assertTrue(booleans.get(64));
+        assertTrue(booleans.get(127));
+    }
+
+    @Test
+    void fillTrue129() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> true, 129);
+
+        assertEquals(129, booleans.size());
+        assertTrue(booleans.get(0));
+        assertTrue(booleans.get(63));
+        assertTrue(booleans.get(64));
+        assertTrue(booleans.get(127));
+        assertTrue(booleans.get(128));
+        assertFalse(booleans.get(129));
+    }
+
+    @Test
+    void fillFalse1() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> false, 1);
+
+        assertEquals(1, booleans.size());
+        assertFalse(booleans.get(0));
+    }
+
+    @Test
+    void fillFalse10() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> false, 10);
+
+        assertEquals(10, booleans.size());
+        assertFalse(booleans.get(0));
+        assertFalse(booleans.get(9));
+    }
+
+    @Test
+    void fillFalseFirst10() {
+        BooleanSeries booleans = BoolBuilder.buildSeries(i -> i >= 10, 20);
+
+        assertEquals(20, booleans.size());
+        assertFalse(booleans.get(0));
+        assertFalse(booleans.get(9));
+        assertTrue(booleans.get(11));
+        assertTrue(booleans.get(19));
+    }
+}

--- a/dflib/src/test/java/org/dflib/builder/BoolBuilderTest.java
+++ b/dflib/src/test/java/org/dflib/builder/BoolBuilderTest.java
@@ -56,7 +56,6 @@ class BoolBuilderTest {
         assertTrue(booleans.get(64));
         assertTrue(booleans.get(127));
         assertTrue(booleans.get(128));
-        assertFalse(booleans.get(129));
     }
 
     @Test


### PR DESCRIPTION
`BooleanBitsetSeries` builder prototype with a usage example in the `Long.eq()` operation.

On my PC this gives following benchmark results:
```
// new builder
Benchmark         (rows)  Mode  Cnt  Score   Error  Units
LongSeriesEq.eq  5000000  avgt    6  1.565 ± 0.036  ms/op

// boolean[] + BooleanArraySeries
Benchmark         (rows)  Mode  Cnt  Score   Error  Units
LongSeriesEq.eq  5000000  avgt    6  1.150 ± 0.011  ms/op

// BoolAccum
Benchmark         (rows)  Mode  Cnt  Score   Error  Units
LongSeriesEq.eq  5000000  avgt    6  3.425 ± 0.345  ms/op

// old BoolAccum on top of java.util.BitSet
Benchmark         (rows)  Mode  Cnt  Score   Error  Units
LongSeriesEq.eq  5000000  avgt    6  4.387 ± 0.284  ms/op
```

See also #326 issue for discussion.