### PR TITLE
Type-specific versions of Exp.$val(..)

### DIFF
--- a/dflib/src/main/java/org/dflib/Exp.java
+++ b/dflib/src/main/java/org/dflib/Exp.java
@@ -48,6 +48,7 @@ import org.dflib.exp.sort.ExpSorter;
 import org.dflib.exp.str.ConcatExp;
 import org.dflib.exp.str.StrColumn;
 import org.dflib.exp.str.StrExp1;
+import org.dflib.exp.str.StrScalarExp;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -88,7 +89,55 @@ public interface Exp<T> {
     }
 
     /**
-     * Returns a DateExp whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * Returns a {@code NumExp<Integer>} whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * returns the value itself.
+     */
+    static IntScalarExp $intVal(int value) {
+        return new IntScalarExp(value);
+    }
+
+    /**
+     * Returns a {@code NumExp<Long>} whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * returns the value itself.
+     */
+    static LongScalarExp $longVal(long value) {
+        return new LongScalarExp(value);
+    }
+
+    /**
+     * Returns a {@code NumExp<Float>} whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * returns the value itself.
+     */
+    static FloatScalarExp $floatVal(float value) {
+        return new FloatScalarExp(value);
+    }
+
+    /**
+     * Returns a {@code NumExp<Double>} whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * returns the value itself.
+     */
+    static DoubleScalarExp $doubleVal(double value) {
+        return new DoubleScalarExp(value);
+    }
+
+    /**
+     * Returns a {@code Condition} whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * returns the value itself.
+     */
+    static BoolScalarExp $boolVal(boolean value) {
+        return value ? BoolScalarExp.TRUE : BoolScalarExp.FALSE;
+    }
+
+    /**
+     * Returns a {@code StrExp} whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * returns the value itself.
+     */
+    static StrScalarExp $strVal(String value) {
+        return new StrScalarExp(value);
+    }
+
+    /**
+     * Returns a {@code DateExp} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
     static DateExp $dateVal(LocalDate value) {
@@ -96,7 +145,7 @@ public interface Exp<T> {
     }
 
     /**
-     * Returns a TimeExp whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * Returns a {@code TimeExp} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
     static TimeExp $timeVal(LocalTime value) {
@@ -104,7 +153,7 @@ public interface Exp<T> {
     }
 
     /**
-     * Returns a DateTimeExp whose "eval" returns a Series with the value argument at each position, and "reduce"
+     * Returns a {@code DateTimeExp} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
     static DateTimeExp $dateTimeVal(LocalDateTime value) {
@@ -129,15 +178,23 @@ public interface Exp<T> {
 
         // create primitive Series aware expressions for faster ops
         if (Integer.class.equals(type) || Integer.TYPE.equals(type)) {
-            return (Exp<T>) new IntScalarExp((Integer) value);
+            return (Exp<T>) $intVal((Integer) value);
         } else if (Long.class.equals(type) || Long.TYPE.equals(type)) {
-            return (Exp<T>) new LongScalarExp((Long) value);
+            return (Exp<T>) $longVal((Long) value);
         } else if (Double.class.equals(type) || Double.TYPE.equals(type)) {
-            return (Exp<T>) new DoubleScalarExp((Double) value);
+            return (Exp<T>) $doubleVal((Double) value);
         } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
-            return (Exp<T>) new BoolScalarExp((Boolean) value);
+            return (Exp<T>) $boolVal((Boolean) value);
         } else if (Float.class.equals(type) || Float.TYPE.equals(type)) {
-            return (Exp<T>) new FloatScalarExp((Float) value);
+            return (Exp<T>) $floatVal((Float) value);
+        } else if (String.class.equals(type)) {
+            return (Exp<T>) $strVal((String) value);
+        } else if (LocalTime.class.equals(type)) {
+            return (Exp<T>) $timeVal((LocalTime) value);
+        } else if (LocalDate.class.equals(type)) {
+            return (Exp<T>) $dateVal((LocalDate) value);
+        } else if (LocalDateTime.class.equals(type)) {
+            return (Exp<T>) $dateTimeVal((LocalDateTime) value);
         } else {
             return new ScalarExp<>(value, type);
         }
@@ -396,11 +453,11 @@ public interface Exp<T> {
     /**
      * Aggregating expression whose "reduce" operation returns the count of rows in the input.
      */
-    static Exp<Integer> count() {
+    static NumExp<Integer> count() {
         return CountExp.getInstance();
     }
 
-    static Exp<Integer> count(Condition filter) {
+    static NumExp<Integer> count(Condition filter) {
         return new CountExp(filter);
     }
 

--- a/dflib/src/main/java/org/dflib/Exp.java
+++ b/dflib/src/main/java/org/dflib/Exp.java
@@ -195,6 +195,8 @@ public interface Exp<T> {
             return (Exp<T>) $dateVal((LocalDate) value);
         } else if (LocalDateTime.class.equals(type)) {
             return (Exp<T>) $dateTimeVal((LocalDateTime) value);
+        } else if (OffsetDateTime.class.equals(type)) {
+            return (Exp<T>) $offsetDateTimeVal((OffsetDateTime) value);
         } else {
             return new ScalarExp<>(value, type);
         }

--- a/dflib/src/main/java/org/dflib/Exp.java
+++ b/dflib/src/main/java/org/dflib/Exp.java
@@ -92,7 +92,7 @@ public interface Exp<T> {
      * Returns a {@code NumExp<Integer>} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
-    static IntScalarExp $intVal(int value) {
+    static NumExp<Integer> $intVal(int value) {
         return new IntScalarExp(value);
     }
 
@@ -100,7 +100,7 @@ public interface Exp<T> {
      * Returns a {@code NumExp<Long>} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
-    static LongScalarExp $longVal(long value) {
+    static NumExp<Long> $longVal(long value) {
         return new LongScalarExp(value);
     }
 
@@ -108,7 +108,7 @@ public interface Exp<T> {
      * Returns a {@code NumExp<Float>} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
-    static FloatScalarExp $floatVal(float value) {
+    static NumExp<Float> $floatVal(float value) {
         return new FloatScalarExp(value);
     }
 
@@ -116,7 +116,7 @@ public interface Exp<T> {
      * Returns a {@code NumExp<Double>} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
-    static DoubleScalarExp $doubleVal(double value) {
+    static NumExp<Double> $doubleVal(double value) {
         return new DoubleScalarExp(value);
     }
 
@@ -124,15 +124,15 @@ public interface Exp<T> {
      * Returns a {@code Condition} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
-    static BoolScalarExp $boolVal(boolean value) {
-        return value ? BoolScalarExp.TRUE : BoolScalarExp.FALSE;
+    static Condition $boolVal(boolean value) {
+        return value ? BoolScalarExp.getTrue() : BoolScalarExp.getFalse();
     }
 
     /**
      * Returns a {@code StrExp} whose "eval" returns a Series with the value argument at each position, and "reduce"
      * returns the value itself.
      */
-    static StrScalarExp $strVal(String value) {
+    static StrExp $strVal(String value) {
         return new StrScalarExp(value);
     }
 
@@ -183,10 +183,10 @@ public interface Exp<T> {
             return (Exp<T>) $longVal((Long) value);
         } else if (Double.class.equals(type) || Double.TYPE.equals(type)) {
             return (Exp<T>) $doubleVal((Double) value);
-        } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
-            return (Exp<T>) $boolVal((Boolean) value);
         } else if (Float.class.equals(type) || Float.TYPE.equals(type)) {
             return (Exp<T>) $floatVal((Float) value);
+        } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
+            return (Exp<T>) $boolVal((Boolean) value);
         } else if (String.class.equals(type)) {
             return (Exp<T>) $strVal((String) value);
         } else if (LocalTime.class.equals(type)) {

--- a/dflib/src/main/java/org/dflib/exp/bool/BoolScalarExp.java
+++ b/dflib/src/main/java/org/dflib/exp/bool/BoolScalarExp.java
@@ -15,6 +15,9 @@ public class BoolScalarExp extends ScalarExp<Boolean> implements Condition {
 
     private final boolean boolValue;
 
+    public static final BoolScalarExp TRUE = new BoolScalarExp(true);
+    public static final BoolScalarExp FALSE = new BoolScalarExp(false);
+
     public BoolScalarExp(boolean value) {
         super(value, Boolean.class);
         this.boolValue = value;

--- a/dflib/src/main/java/org/dflib/exp/bool/BoolScalarExp.java
+++ b/dflib/src/main/java/org/dflib/exp/bool/BoolScalarExp.java
@@ -15,8 +15,8 @@ public class BoolScalarExp extends ScalarExp<Boolean> implements Condition {
 
     private final boolean boolValue;
 
-    public static final BoolScalarExp TRUE = new BoolScalarExp(true);
-    public static final BoolScalarExp FALSE = new BoolScalarExp(false);
+    private static final BoolScalarExp TRUE = new BoolScalarExp(true);
+    private static final BoolScalarExp FALSE = new BoolScalarExp(false);
 
     public BoolScalarExp(boolean value) {
         super(value, Boolean.class);
@@ -31,6 +31,14 @@ public class BoolScalarExp extends ScalarExp<Boolean> implements Condition {
     @Override
     public BooleanSeries eval(Series<?> s) {
         return doEval(s.size());
+    }
+
+    public static Condition getTrue() {
+        return BoolScalarExp.TRUE;
+    }
+
+    public static Condition getFalse() {
+        return BoolScalarExp.FALSE;
     }
 
     private BooleanSeries doEval(int height) {


### PR DESCRIPTION
## What does this PR do

Adds several `*Val()` methods to the Exp API.
This change is expected to reduce typecasting in the future.