### PR TITLE
Better guess at "Series.nominalType"

### DIFF
--- a/dflib/src/main/java/org/dflib/collection/JavaArrays.java
+++ b/dflib/src/main/java/org/dflib/collection/JavaArrays.java
@@ -1,0 +1,17 @@
+package org.dflib.collection;
+
+import java.lang.reflect.Array;
+
+/**
+ * @since 2.0.0
+ */
+// Not calling this "Arrays" to avoid confusion with "java.util.Arrays"
+public class JavaArrays {
+
+    public static <T> T[] newArray(Class<?> componentType, int len) {
+        // TODO: convert primitive types to their corresponding boxed types
+        return Object.class == componentType || componentType.isPrimitive()
+                ? (T[]) new Object[len]
+                : (T[]) Array.newInstance(componentType, len);
+    }
+}

--- a/dflib/src/main/java/org/dflib/series/ArrayRangeSeries.java
+++ b/dflib/src/main/java/org/dflib/series/ArrayRangeSeries.java
@@ -16,7 +16,14 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
     private final int offset;
     private final int size;
 
-    public ArrayRangeSeries(Class<?> nominalType, T[] data, int offset, int size) {
+    /**
+     * @since 2.0.0
+     */
+    public ArrayRangeSeries(T[] data, int offset, int size) {
+        this(data.getClass().getComponentType(), data, offset, size);
+    }
+
+    ArrayRangeSeries(Class<?> nominalType, T[] data, int offset, int size) {
         super(nominalType);
         this.data = data;
         this.offset = offset;
@@ -50,12 +57,11 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
     public Series<T> materialize() {
 
         if (offset == 0 && size == data.length) {
-            return new ArraySeries(data);
+            return new ArraySeries<>(nominalType, data);
         }
 
-        Object[] data = new Object[size];
-        copyTo(data, 0, 0, size);
-        return new ArraySeries(data);
+        T[] copy = Arrays.copyOfRange(data, offset, offset + size);
+        return new ArraySeries<>(nominalType, copy);
     }
 
     @Override
@@ -67,8 +73,7 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
             if (data[offset + i] == null) {
 
                 if (copy == null) {
-                    copy = (T[]) new Object[size];
-                    System.arraycopy(data, offset, copy, 0, size);
+                    copy = Arrays.copyOfRange(data, offset, offset + size);
                 }
 
                 copy[i] = value;
@@ -86,8 +91,7 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
             if (data[offset + i] == null) {
 
                 if (copy == null) {
-                    copy = (T[]) new Object[size];
-                    System.arraycopy(data, offset, copy, 0, size);
+                    copy = Arrays.copyOfRange(data, offset, offset + size);
                 }
 
                 copy[i] = values.get(i);
@@ -106,8 +110,7 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
             if (data[offset + i] == null) {
 
                 if (copy == null) {
-                    copy = (T[]) new Object[size];
-                    System.arraycopy(data, offset, copy, 0, size);
+                    copy = Arrays.copyOfRange(data, offset, offset + size);
                 }
 
                 if (fillFrom < 0) {
@@ -135,8 +138,7 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
                 }
 
                 if (copy == null) {
-                    copy = (T[]) new Object[size];
-                    System.arraycopy(data, offset, copy, 0, size);
+                    copy = Arrays.copyOfRange(data, offset, offset + size);
                 }
 
                 copy[i] = copy[i - 1];
@@ -150,6 +152,6 @@ public class ArrayRangeSeries<T> extends ObjectSeries<T> {
     public Series<T> selectRange(int fromInclusive, int toExclusive) {
         return fromInclusive == 0 && toExclusive == size()
                 ? this
-                : new ArrayRangeSeries<>(getNominalType(), data, offset + fromInclusive, toExclusive - fromInclusive);
+                : new ArrayRangeSeries<>(nominalType, data, offset + fromInclusive, toExclusive - fromInclusive);
     }
 }

--- a/dflib/src/main/java/org/dflib/series/ArraySeries.java
+++ b/dflib/src/main/java/org/dflib/series/ArraySeries.java
@@ -10,7 +10,12 @@ public class ArraySeries<T> extends ObjectSeries<T> {
 
     @SafeVarargs
     public ArraySeries(T... data) {
-        super(Object.class);
+        this(data.getClass().getComponentType(), data);
+    }
+
+    @SafeVarargs
+    ArraySeries(Class<?> nominalType, T... data) {
+        super(nominalType);
         this.data = data;
     }
 
@@ -44,15 +49,14 @@ public class ArraySeries<T> extends ObjectSeries<T> {
             if (data[i] == null) {
 
                 if (copy == null) {
-                    copy = (T[]) new Object[len];
-                    System.arraycopy(data, 0, copy, 0, len);
+                    copy = Arrays.copyOf(data, len);
                 }
 
                 copy[i] = value;
             }
         }
 
-        return copy != null ? new ArraySeries<>(copy) : this;
+        return copy != null ? new ArraySeries<>(nominalType, copy) : this;
     }
 
     @Override
@@ -64,15 +68,14 @@ public class ArraySeries<T> extends ObjectSeries<T> {
             if (data[i] == null) {
 
                 if (copy == null) {
-                    copy = (T[]) new Object[len];
-                    System.arraycopy(data, 0, copy, 0, len);
+                    copy = Arrays.copyOf(data, len);
                 }
 
                 copy[i] = values.get(i);
             }
         }
 
-        return copy != null ? new ArraySeries<>(copy) : this;
+        return copy != null ? new ArraySeries<>(nominalType, copy) : this;
     }
 
     @Override
@@ -85,8 +88,7 @@ public class ArraySeries<T> extends ObjectSeries<T> {
             if (data[i] == null) {
 
                 if (copy == null) {
-                    copy = (T[]) new Object[len];
-                    System.arraycopy(data, 0, copy, 0, len);
+                    copy = Arrays.copyOf(data, len);
                 }
 
                 if (fillFrom < 0) {
@@ -98,7 +100,7 @@ public class ArraySeries<T> extends ObjectSeries<T> {
             }
         }
 
-        return copy != null ? new ArraySeries<>(copy) : this;
+        return copy != null ? new ArraySeries<>(nominalType, copy) : this;
     }
 
     @Override
@@ -115,21 +117,20 @@ public class ArraySeries<T> extends ObjectSeries<T> {
                 }
 
                 if (copy == null) {
-                    copy = (T[]) new Object[len];
-                    System.arraycopy(data, 0, copy, 0, len);
+                    copy = Arrays.copyOf(data, len);
                 }
 
                 copy[i] = copy[i - 1];
             }
         }
 
-        return copy != null ? new ArraySeries<>(copy) : this;
+        return copy != null ? new ArraySeries<>(nominalType, copy) : this;
     }
 
     @Override
     public Series<T> selectRange(int fromInclusive, int toExclusive) {
         return fromInclusive == 0 && toExclusive == size()
                 ? this
-                : new ArrayRangeSeries(getNominalType(), data, fromInclusive, toExclusive - fromInclusive);
+                : new ArrayRangeSeries<>(nominalType, data, fromInclusive, toExclusive - fromInclusive);
     }
 }

--- a/dflib/src/main/java/org/dflib/series/ColumnMappedSeries.java
+++ b/dflib/src/main/java/org/dflib/series/ColumnMappedSeries.java
@@ -10,6 +10,7 @@ public class ColumnMappedSeries<S, T> extends ObjectSeries<T> {
     private Series<T> materialized;
 
     public ColumnMappedSeries(Series<S> source, ValueMapper<S, T> mapper) {
+        // TODO: we can't infer the target type from the ValueMapper, so using Object
         super(Object.class);
         this.source = source;
         this.mapper = mapper;
@@ -44,9 +45,10 @@ public class ColumnMappedSeries<S, T> extends ObjectSeries<T> {
     }
 
     protected ArraySeries<T> doMaterialize() {
-        Object[] data = new Object[size()];
+        // TODO: see the constructor note.. They type of array is always Object
+        T[] data = (T[]) new Object[size()];
 
-        for(int i = 0; i < data.length; i++) {
+        for (int i = 0; i < data.length; i++) {
             data[i] = mapper.map(source.get(i));
         }
 
@@ -54,7 +56,7 @@ public class ColumnMappedSeries<S, T> extends ObjectSeries<T> {
         source = null;
         mapper = null;
 
-        return new ArraySeries<>((T[]) data);
+        return new ArraySeries<>(data);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/ObjectSeries.java
+++ b/dflib/src/main/java/org/dflib/series/ObjectSeries.java
@@ -12,6 +12,7 @@ import org.dflib.ValueMapper;
 import org.dflib.ValueToRowMapper;
 import org.dflib.builder.IntAccum;
 import org.dflib.builder.ObjectAccum;
+import org.dflib.collection.JavaArrays;
 import org.dflib.concat.SeriesConcat;
 import org.dflib.groupby.SeriesGrouper;
 import org.dflib.map.Mapper;
@@ -31,7 +32,7 @@ import java.util.function.Predicate;
 
 public abstract class ObjectSeries<T> implements Series<T> {
 
-    protected Class<?> nominalType;
+    protected final Class<?> nominalType;
     protected Class<?> inferredType;
 
     protected ObjectSeries(Class<?> nominalType) {
@@ -52,6 +53,9 @@ public abstract class ObjectSeries<T> implements Series<T> {
 
         // Check value types and use the most specific common superclass...
         Class<?> type = null;
+
+        // not using "nominalType" as terminal, as it can be an interface
+        // TODO: any other special cases that would prevent us from using "nominalType" as terminal?
         Class<?> terminal = Object.class;
         int size = size();
 
@@ -309,7 +313,7 @@ public abstract class ObjectSeries<T> implements Series<T> {
     @Override
     public Series<T> replace(Map<T, T> oldToNewValues) {
         int len = size();
-        T[] replaced = (T[]) new Object[len];
+        T[] replaced = JavaArrays.newArray(nominalType, len);
 
         for (int i = 0; i < len; i++) {
             T val = get(i);
@@ -425,7 +429,9 @@ public abstract class ObjectSeries<T> implements Series<T> {
         }
 
         Set<T> unique = toSet();
-        return unique.size() < size() ? new ArraySeries<>(unique.toArray(s -> (T[]) new Object[s])) : this;
+        return unique.size() < size()
+                ? new ArraySeries<>(unique.toArray(len -> JavaArrays.newArray(nominalType, len)))
+                : this;
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/series/OffsetLagSeries.java
+++ b/dflib/src/main/java/org/dflib/series/OffsetLagSeries.java
@@ -1,6 +1,7 @@
 package org.dflib.series;
 
 import org.dflib.Series;
+import org.dflib.collection.JavaArrays;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -68,16 +69,16 @@ public class OffsetLagSeries<T> extends OffsetSeries<T> {
     @Override
     public Series<T> materialize() {
 
-        int size = size();
-        int splitPoint = size + offset;
-        Object[] buffer = new Object[size];
+        int len = size();
+        int splitPoint = len + offset;
+        T[] data = JavaArrays.newArray(nominalType, len);
 
-        delegate.copyTo(buffer, -offset, 0, splitPoint);
+        delegate.copyTo(data, -offset, 0, splitPoint);
 
         if (filler != null) {
-            Arrays.fill(buffer, splitPoint, size, filler);
+            Arrays.fill(data, splitPoint, len, filler);
         }
 
-        return new ArraySeries<>((T[]) buffer);
+        return new ArraySeries<>(data);
     }
 }

--- a/dflib/src/main/java/org/dflib/series/OffsetLeadSeries.java
+++ b/dflib/src/main/java/org/dflib/series/OffsetLeadSeries.java
@@ -1,6 +1,7 @@
 package org.dflib.series;
 
 import org.dflib.Series;
+import org.dflib.collection.JavaArrays;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -65,14 +66,14 @@ public class OffsetLeadSeries<T> extends OffsetSeries<T> {
     public Series<T> materialize() {
 
         int size = size();
-        Object[] buffer = new Object[size];
+        T[] data = JavaArrays.newArray(nominalType, size);
 
         if (filler != null) {
-            Arrays.fill(buffer, 0, offset, filler);
+            Arrays.fill(data, 0, offset, filler);
         }
 
-        delegate.copyTo(buffer, 0, offset, size - offset);
+        delegate.copyTo(data, 0, offset, size - offset);
 
-        return new ArraySeries<>((T[]) buffer);
+        return new ArraySeries<>(data);
     }
 }

--- a/dflib/src/main/java/org/dflib/series/RangeSeries.java
+++ b/dflib/src/main/java/org/dflib/series/RangeSeries.java
@@ -1,6 +1,7 @@
 package org.dflib.series;
 
 import org.dflib.Series;
+import org.dflib.collection.JavaArrays;
 import org.dflib.range.Range;
 
 /**
@@ -46,9 +47,9 @@ public class RangeSeries<T> extends ObjectSeries<T> {
 
     @Override
     public Series<T> materialize() {
-        Object[] range = new Object[size];
+        T[] range = JavaArrays.newArray(nominalType, size);
         delegate.copyTo(range, this.offset, 0, size);
-        return new ArraySeries<>((T[]) range);
+        return new ArraySeries<>(range);
     }
 
     @Override

--- a/dflib/src/main/java/org/dflib/slice/DefaultRowSetMerger.java
+++ b/dflib/src/main/java/org/dflib/slice/DefaultRowSetMerger.java
@@ -3,6 +3,7 @@ package org.dflib.slice;
 import org.dflib.BooleanSeries;
 import org.dflib.IntSeries;
 import org.dflib.Series;
+import org.dflib.collection.JavaArrays;
 
 class DefaultRowSetMerger extends RowSetMerger {
 
@@ -27,7 +28,7 @@ class DefaultRowSetMerger extends RowSetMerger {
         int h = mergeIndex.length;
 
         // TODO: primitive Series
-        T[] values = (T[]) new Object[h];
+        T[] values = JavaArrays.newArray(srcColumn.getNominalType(), h);
 
         for (int i = 0; i < h; i++) {
             int si = mergeIndex[i];

--- a/dflib/src/main/java/org/dflib/slice/RangeRowSetMerger.java
+++ b/dflib/src/main/java/org/dflib/slice/RangeRowSetMerger.java
@@ -2,6 +2,7 @@ package org.dflib.slice;
 
 import org.dflib.BooleanSeries;
 import org.dflib.Series;
+import org.dflib.collection.JavaArrays;
 import org.dflib.range.Range;
 import org.dflib.series.IntSequenceSeries;
 
@@ -39,7 +40,7 @@ class RangeRowSetMerger extends RowSetMerger {
         }
 
         // TODO: primitive Series
-        T[] values = (T[]) new Object[srcLen];
+        T[] values = JavaArrays.newArray(rsColumn.getNominalType(), srcLen);
 
         if (fromInclusive > 0) {
             srcColumn.copyTo(values, 0, 0, fromInclusive);

--- a/dflib/src/main/java/org/dflib/sort/SeriesSorter.java
+++ b/dflib/src/main/java/org/dflib/sort/SeriesSorter.java
@@ -3,6 +3,7 @@ package org.dflib.sort;
 import org.dflib.IntSeries;
 import org.dflib.Series;
 import org.dflib.Sorter;
+import org.dflib.collection.JavaArrays;
 import org.dflib.series.ArraySeries;
 import org.dflib.series.IntArraySeries;
 
@@ -51,7 +52,7 @@ public class SeriesSorter<T> {
         //  than this specialized impl (an extra int[] allocation)
 
         int size = s.size();
-        T[] sorted = (T[]) new Object[size];
+        T[] sorted = JavaArrays.newArray(s.getNominalType(), size);
         s.copyTo(sorted, 0, 0, size);
         Arrays.sort(sorted, comparator);
         return new ArraySeries<>(sorted);

--- a/dflib/src/test/java/org/dflib/SeriesType.java
+++ b/dflib/src/test/java/org/dflib/SeriesType.java
@@ -19,7 +19,7 @@ public enum SeriesType {
             case RANGE:
                 return new RangeSeries<>(new ArraySeries<>(data), 0, data.length);
             case ARRAY_RANGE:
-                return new ArrayRangeSeries<>(Object.class, data, 0, data.length);
+                return new ArrayRangeSeries<>(data, 0, data.length);
             default:
                 throw new IllegalStateException("Unknown series type: " + this);
         }

--- a/dflib/src/test/java/org/dflib/series/ArrayRangeSeriesTest.java
+++ b/dflib/src/test/java/org/dflib/series/ArrayRangeSeriesTest.java
@@ -1,0 +1,29 @@
+package org.dflib.series;
+
+import org.dflib.Series;
+import org.dflib.unit.SeriesAsserts;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArrayRangeSeriesTest {
+
+    @Test
+    void nominalType() {
+        String[] s = IntStream.range(0, 33).mapToObj(String::valueOf).toArray(String[]::new);
+        ArrayRangeSeries<String> r1 = new ArrayRangeSeries<>(s, 25, 8);
+
+        assertEquals(String.class, r1.getNominalType());
+    }
+
+    @Test
+    void materialize() {
+        Integer[] s = IntStream.range(0, 33).mapToObj(Integer::valueOf).toArray(Integer[]::new);
+        Series<Integer> r1 = new ArrayRangeSeries<>(s, 25, 8).materialize();
+
+        new SeriesAsserts(r1).expectData(25, 26, 27, 28, 29, 30, 31, 32);
+        assertEquals(Integer.class, r1.getNominalType());
+    }
+}

--- a/dflib/src/test/java/org/dflib/series/ArrayRangeSeries_HeadTest.java
+++ b/dflib/src/test/java/org/dflib/series/ArrayRangeSeries_HeadTest.java
@@ -11,10 +11,10 @@ public class ArrayRangeSeries_HeadTest {
     void test() {
         String[] s = IntStream.range(0, 33).mapToObj(String::valueOf).toArray(String[]::new);
 
-        ArrayRangeSeries<String> r1 = new ArrayRangeSeries<>(String.class, s, 25, 8);
+        ArrayRangeSeries<String> r1 = new ArrayRangeSeries<>(s, 25, 8);
         new SeriesAsserts(r1.head(3)).expectData("25", "26", "27");
 
-        ArrayRangeSeries<String> r2 = new ArrayRangeSeries<>(String.class, s, 24, 9);
+        ArrayRangeSeries<String> r2 = new ArrayRangeSeries<>(s, 24, 9);
         new SeriesAsserts(r2.head(3)).expectData("24", "25", "26");
     }
 }

--- a/dflib/src/test/java/org/dflib/series/ArrayRangeSeries_TailTest.java
+++ b/dflib/src/test/java/org/dflib/series/ArrayRangeSeries_TailTest.java
@@ -11,10 +11,10 @@ public class ArrayRangeSeries_TailTest {
     void test() {
         String[] s = IntStream.range(0, 33).mapToObj(String::valueOf).toArray(String[]::new);
 
-        ArrayRangeSeries<String> r1 = new ArrayRangeSeries<>(String.class, s, 25, 8);
+        ArrayRangeSeries<String> r1 = new ArrayRangeSeries<>(s, 25, 8);
         new SeriesAsserts(r1.tail(3)).expectData("30", "31", "32");
 
-        ArrayRangeSeries<String> r2 = new ArrayRangeSeries<>(String.class, s, 24, 9);
+        ArrayRangeSeries<String> r2 = new ArrayRangeSeries<>(s, 24, 9);
         new SeriesAsserts(r2.tail(3)).expectData("30", "31", "32");
     }
 }

--- a/dflib/src/test/java/org/dflib/series/ArraySeriesTest.java
+++ b/dflib/src/test/java/org/dflib/series/ArraySeriesTest.java
@@ -1,0 +1,33 @@
+package org.dflib.series;
+
+import org.dflib.Series;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArraySeriesTest {
+
+    @Test
+    void nominalType() {
+        ArraySeries<Object> s1 = new ArraySeries<>("a", 5, null);
+        assertEquals(Object.class, s1.getNominalType());
+
+        ArraySeries<String> s2 = new ArraySeries<>("a", "b", null);
+        assertEquals(String.class, s2.getNominalType());
+
+        ArraySeries<Integer> s3 = new ArraySeries<>(1, 2, null);
+        assertEquals(Integer.class, s3.getNominalType());
+    }
+
+    @Test
+    void fillNulls_PreserveNominalType() {
+        Series<Object> s1 = new ArraySeries<>("a", 5, null);
+        assertEquals(Object.class, s1.fillNulls(new Object()).getNominalType());
+
+        ArraySeries<String> s2 = new ArraySeries<>("a", "b", null);
+        assertEquals(String.class, s2.fillNulls("c").getNominalType());
+
+        ArraySeries<Integer> s3 = new ArraySeries<>(1, 2, null);
+        assertEquals(Integer.class, s3.fillNulls(6).getNominalType());
+    }
+}


### PR DESCRIPTION
This PR attempts to improve `Series.nominalType` (i.e. the "cheap" type checker for columns) primarily by checking array types in Series constructors, and passing that type around during transformations. 

Not merging to `main` yet, as it is unclear how much of a performance impact we are adding by dynamically creating arrays based on type, and also using arrays that are not `Object[]` (does it incur extra type checking overhead on element assignments?) 

Will need to run speed and memory benchmarks. 