### PR TITLE
Implement concatenation op for the `BooleanBitsetSeries`

### DIFF
--- a/dflib/src/main/java/org/dflib/series/BooleanBitsetSeries.java
+++ b/dflib/src/main/java/org/dflib/series/BooleanBitsetSeries.java
@@ -143,6 +143,45 @@ public class BooleanBitsetSeries extends BooleanBaseSeries {
     }
 
     @Override
+    public BooleanSeries concatBool(BooleanSeries... other) {
+        if (other.length == 0) {
+            return this;
+        }
+
+        int size = size();
+        int h = size;
+        for (BooleanSeries s : other) {
+            if(!(s instanceof BooleanBitsetSeries)) {
+                // TODO: sanity check, shouldn't be a case anymore, so may as well just throw an exception
+                return super.concatBool(other);
+            }
+            h += s.size();
+        }
+
+        long[] result = new long[arraySize(h)];
+        // copy this series as is
+        System.arraycopy(this.data, 0, result, 0, this.data.length);
+
+        // shift and pack other series
+        int currentSizeInBits = size;
+        for(BooleanSeries s : other) {
+            BooleanBitsetSeries nextBitsetSeries = (BooleanBitsetSeries) s;
+            int bitsLeft = nextBitsetSeries.size();
+            for(long nextLong : nextBitsetSeries.data) {
+                int nextIndex = arraySize(currentSizeInBits);
+                result[nextIndex - 1] |= nextLong << currentSizeInBits;
+                if(nextIndex < result.length) {
+                    result[nextIndex] |= nextLong >>> -currentSizeInBits;
+                }
+                currentSizeInBits += Math.min(bitsLeft, Long.SIZE);
+                bitsLeft -= Long.SIZE;
+            }
+        }
+
+        return new BooleanBitsetSeries(result, h);
+    }
+
+    @Override
     public BooleanSeries sort(Sorter... sorters) {
         return selectAsBooleanSeries(new SeriesSorter<>(this).sortIndex(sorters));
     }

--- a/dflib/src/test/java/org/dflib/series/BooleanBitsetSeriesTest.java
+++ b/dflib/src/test/java/org/dflib/series/BooleanBitsetSeriesTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class BooleanBitsetSeriesTest {
 
+    static final long LONG_BITS_MASK = 0xFFFFFFFF_FFFFFFFFL;
+
     @Test
     public void create() {
         long[] data = {
@@ -193,5 +195,119 @@ class BooleanBitsetSeriesTest {
     public void cumSum() {
         BooleanBitsetSeries s = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
         new SeriesAsserts(s.cumSum()).expectData(1, 1, 1, 2);
+    }
+
+    @Test
+    public void concatBool() {
+        {
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{0b1001_1001_1001L}, 12);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(12, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
+
+        {
+
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001}, 68);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001_1001_1001L}, 76);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(76, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
+
+        {
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001}, 68);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001}, 68);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{0b1001L}, 4);
+
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L,
+                    0b00001001_10011111L
+            }, 140);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(140, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
+
+        {
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001}, 68);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001}, 68);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, 0b1001}, 68);
+
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_10011111L,
+                    0b00001001_11111111L
+            }, 204);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(68+68+68, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
+
+        {
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, LONG_BITS_MASK, 0b1001}, 132);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, LONG_BITS_MASK, 0b1001}, 132);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, LONG_BITS_MASK, 0b1001}, 132);
+
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_10011111L,
+                    0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b00001001_11111111L
+            }, 396);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(132+132+132, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
+
+        {
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{0b00001111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L}, 60);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{0b00001111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L}, 60);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{0b00001111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L}, 60);
+
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{
+                    0b10011111_11111111_11111111_11111111_11111111_11111111_11111111_11111001L,
+                    0b11111001_11111111_11111111_11111111_11111111_11111111_11111111_11111111L,
+                    0b00000000_00001111_11111111_11111111_11111111_11111111_11111111_11111111L,
+            }, 180);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(180, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
+
+        {
+            BooleanBitsetSeries s1 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, LONG_BITS_MASK}, 128);
+            BooleanBitsetSeries s2 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, LONG_BITS_MASK}, 128);
+            BooleanBitsetSeries s3 = new BooleanBitsetSeries(new long[]{LONG_BITS_MASK, LONG_BITS_MASK}, 128);
+
+            BooleanBitsetSeries concat = new BooleanBitsetSeries(new long[]{
+                    LONG_BITS_MASK,
+                    LONG_BITS_MASK,
+                    LONG_BITS_MASK,
+                    LONG_BITS_MASK,
+                    LONG_BITS_MASK,
+                    LONG_BITS_MASK
+            }, 384);
+
+            BooleanSeries booleans = s1.concatBool(s2, s3);
+            assertEquals(384, booleans.size());
+            assertTrue(concat.eq(booleans).isTrue());
+        }
     }
 }


### PR DESCRIPTION
This is a part of #326, providing efficient implementation of the `concatBool()` operation for the bitset-based boolean series.

After this PR and #366 applied `BooleanArraySeries` would be completely replaced by the `BooleanBitsetSeries`.

Some benchmark data, concatenation of 3 series with 500K elements each:
Current implementation of `concatBool()`  for `BooleanArraySeries`: **36μs**
Current implementation of `concatBool()`  for `BooleanBitsetSeries`: **725μs**
New implementation of `concatBool()`  for `BooleanBitsetSeries`: **16μs**