### PR TITLE
ECharts can not be displayed in VSCode (and GitHub) #410

### DIFF
--- a/dflib-echarts/src/main/resources/org/dflib/echarts/html_embedded.mustache
+++ b/dflib-echarts/src/main/resources/org/dflib/echarts/html_embedded.mustache
@@ -2,20 +2,51 @@
 {{{chartDiv}}}
 <script type='text/javascript'>
 function dflibEchartLoad_{{id}}(src, currentScript) {
-    return new Promise(function (resolve, reject) {
-        var s = document.createElement("script");
-        s.src = src;
-        s.onload = resolve;
-        s.onerror = reject;
-        currentScript.parentNode.insertBefore(s, currentScript);
-    });
+  const savedDefine = window.define;
+  const savedAmd = savedDefine && savedDefine.amd;
+
+  // Temporarily disable AMD detection so UMD chooses globalThis/window branch
+  if (savedDefine && savedAmd) {
+    try { delete savedDefine.amd; } catch { savedDefine.amd = undefined; }
+  }
+
+  return new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = src;
+
+    s.onload = () => {
+      // restore AMD flag
+      if (savedDefine) savedDefine.amd = savedAmd;
+
+      // verify
+      if (window.echarts && typeof window.echarts.init === "function") resolve(window.echarts);
+      else reject(new Error("ECharts loaded, but window.echarts.init is missing"));
+    };
+
+    s.onerror = (e) => {
+      // restore AMD flag
+      if (savedDefine) savedDefine.amd = savedAmd;
+      reject(e);
+    };
+
+    // insert safely even if currentScript becomes detached
+    const parent = currentScript && currentScript.parentNode;
+    if (parent) parent.insertBefore(s, currentScript);
+    else (document.head || document.documentElement).appendChild(s);
+  });
 }
 
 (async function () {
     const cs = document.currentScript;
-    if (!window.echarts) {
+    if (!window.echarts || !window.echarts.init) {
         await dflibEchartLoad_{{id}}('{{{echartsUrl}}}', cs);
+
+        if (!window.echarts || !window.echarts.init) {
+            console.error('ECharts failed to load!');
+            return;
+        }
     }
+
     {{#themeUrls}}
     await dflibEchartLoad_{{id}}('{{{.}}}', cs);
     {{/themeUrls}}


### PR DESCRIPTION
This pull request improves the robustness and compatibility of the ECharts loading logic in the embedded HTML template. The main focus is to ensure ECharts loads correctly in environments with AMD loaders (such as RequireJS) and to provide better error handling and script insertion logic.

**Enhancements to ECharts loading and error handling:**

* Temporarily disables AMD detection before loading ECharts to ensure the UMD build attaches to the global object, then restores the AMD flag after loading. This prevents conflicts with AMD loaders like RequireJS.
* Adds verification after script load to confirm that `window.echarts.init` is available, and rejects with an error if not, improving reliability.
* Improves script insertion logic to handle cases where `currentScript` may be detached from the DOM, falling back to inserting into `document.head` or `document.documentElement`.
* Enhances error handling by restoring the AMD flag on script load failure and providing more informative error messages in the console if ECharts fails to load.