### PR TITLE
change the echarts script URL from CDN using the most recent

### DIFF
--- a/dflib-echarts/src/main/java/org/dflib/echarts/EChart.java
+++ b/dflib-echarts/src/main/java/org/dflib/echarts/EChart.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  */
 public class EChart {
 
-    private static final String DEFAULT_ECHARTS_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/echarts@6.0.0/dist/echarts.min.js";
+    private static final String DEFAULT_ECHARTS_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/echarts@latest/dist/echarts.min.js";
 
     private final ElementIdGenerator idGenerator;
     private final Option option;


### PR DESCRIPTION
By doing this, the echarts library's hardcoded version will be avoided. It will always use the most recent CDN version.